### PR TITLE
엔트리페이지 및 헤더 반응형 레이아웃 제작

### DIFF
--- a/src/components/Enter/EnterTitle.tsx
+++ b/src/components/Enter/EnterTitle.tsx
@@ -1,24 +1,27 @@
-import styled from 'styled-components';
-
+import styled from "styled-components";
 
 const EnterTitle = () => (
   <TitleLayout>
-		이 세상 <br /> 모든 스터디의 <br />
-		<span className="brand">
-			Hi<span className="white">-</span>Fi
-		</span>
-		를 위해
-	</TitleLayout>
-)
+    이 세상 <br /> 모든 스터디의 <br />
+    <span className="brand">
+      Hi<span className="white">-</span>Fi
+    </span>
+    를 위해
+  </TitleLayout>
+);
 
-export default EnterTitle
-
+export default EnterTitle;
 
 const TitleLayout = styled.div`
   font-family: "Nunito_Black";
   font-size: 72px;
   padding: 3em 0 2em 0;
   line-height: normal;
+
+  @media (max-width: 768px) {
+    font-size: 36px;
+  }
+
   .brand {
     font-family: "Nunito_ExtraBoldItalic";
     color: ${({ theme }) => theme.colors.basicBlue};

--- a/src/components/Enter/index.tsx
+++ b/src/components/Enter/index.tsx
@@ -2,43 +2,45 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 import { FiArrowDown } from "react-icons/fi";
-import { ROUTE } from 'util/constants';
-import { RoundButton } from 'components/Common';
-import EnterTitle from './EnterTitle';
+import { ROUTE } from "util/constants";
+import { RoundButton } from "components/Common";
+import EnterTitle from "./EnterTitle";
 
 const Enter = () => {
-
   return (
     <HeroLayout>
-        <EnterTitle/>
-        <Buttons>
-          <LinkButton>Download Mobile App</LinkButton>
-          <Link to={ROUTE.LOGIN}>
-            <LinkButton>Go To Service</LinkButton>
-          </Link>
-        </Buttons>
-        <Guide>
-          <span>Introduce HiFi, Scroll down</span>
-          <FiArrowDown size={84} />
-        </Guide>
+      <EnterTitle />
+      <Buttons>
+        <Link to={ROUTE.LOGIN}>
+          <LinkButton>Go To Service</LinkButton>
+        </Link>
+      </Buttons>
+      <Guide>
+        <span>Introduce HiFi, Scroll down</span>
+        <FiArrowDown size={84} />
+      </Guide>
     </HeroLayout>
   );
 };
 export default Enter;
 
 const HeroLayout = styled.div`
-  padding: 0 200px;
-  height:1080px;
+  padding: ${({ theme }) => theme.paddingByDevice.desktop};
+
+  @media (max-width: 768px) {
+    padding: ${({ theme }) => theme.paddingByDevice.mobile};
+    background-position: right 30% top 0%;
+  }
+
+  height: 1080px;
   background-image: url("/hero.jpg");
   background-repeat: no-repeat;
   background-size: cover;
   color: ${({ theme }) => theme.grayScaleColors.offWhite};
 `;
 
-
 const Buttons = styled.div`
-  display: flex;
-  justify-content: space-between;
+  ${({ theme }) => theme.flexSet()};
 `;
 
 const LinkButton = styled(RoundButton)`

--- a/src/components/Enter/index.tsx
+++ b/src/components/Enter/index.tsx
@@ -46,6 +46,13 @@ const Buttons = styled.div`
 const LinkButton = styled(RoundButton)`
   width: 400px;
   height: 100px;
+
+  @media (max-width: 768px) {
+    width: 200px;
+    height: 50px;
+    font-size: 15px;
+  }
+
   background-color: ${({ theme }) => theme.colors.basicBlue};
   color: ${({ theme }) => theme.grayScaleColors.offWhite};
   font-family: "Nunito_Bold";
@@ -63,5 +70,8 @@ const Guide = styled.div`
   justify-content: space-between;
   align-self: center;
   align-items: center;
+  @media (max-width: 768px) {
+    margin-top: 100px;
+  }
   margin-top: 150px;
 `;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -39,8 +39,14 @@ export default Header;
 
 const HeaderLayout = styled.div<{ isHeaderTop: Boolean }>`
   ${({ theme }) => theme.flexSet("space-between")};
-  width: 100%;
+  width: ${({ theme }) => theme.widthByDevice.desktop};
   height: 64px;
+
+  @media (max-width: 768px) {
+    width: ${({ theme }) => theme.widthByDevice.mobile};
+    padding: 0 2em;
+  }
+
   padding: 0 200px;
   position: fixed;
   box-shadow: ${({ isHeaderTop }) => (isHeaderTop ? "none" : "0.3em 0.3em 1em rgba(0, 0, 0, 0.3)")};

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -44,10 +44,10 @@ const HeaderLayout = styled.div<{ isHeaderTop: Boolean }>`
 
   @media (max-width: 768px) {
     width: ${({ theme }) => theme.widthByDevice.mobile};
-    padding: 0 2em;
+    padding: ${({ theme }) => theme.paddingByDevice.mobile};
   }
 
-  padding: 0 200px;
+  padding: ${({ theme }) => theme.paddingByDevice.desktop};
   position: fixed;
   box-shadow: ${({ isHeaderTop }) => (isHeaderTop ? "none" : "0.3em 0.3em 1em rgba(0, 0, 0, 0.3)")};
   background-color: ${({ isHeaderTop, theme }) => (isHeaderTop ? "transparent" : `${theme.grayScaleColors.offWhite}`)};

--- a/src/util/styles/theme/index.ts
+++ b/src/util/styles/theme/index.ts
@@ -26,6 +26,10 @@ const theme: DefaultTheme = {
     desktop: "1920px",
     mobile: "100vw",
   },
+  paddingByDevice: {
+    desktop: "0 200px",
+    mobile: "0 2em",
+  },
   flexSet: (horizon?: string, vertical?: string, direction?: string) => css`
     display: flex;
     justify-content: ${horizon || "center"};

--- a/src/util/styles/theme/index.ts
+++ b/src/util/styles/theme/index.ts
@@ -22,6 +22,10 @@ const theme: DefaultTheme = {
     background: "#F7F7FC",
     offWhite: "#FEFEFE",
   },
+  widthByDevice: {
+    desktop: "1920px",
+    mobile: "100vw",
+  },
   flexSet: (horizon?: string, vertical?: string, direction?: string) => css`
     display: flex;
     justify-content: ${horizon || "center"};

--- a/src/util/styles/theme/styled.d.ts
+++ b/src/util/styles/theme/styled.d.ts
@@ -22,7 +22,7 @@ declare module "styled-components" {
     | "lightRed"
     | "darkRed";
   type TOptions = "horizon" | "vertical" | "direction";
-  type TWidth = "desktop" | "mobile";
+  type TDevices = "desktop" | "mobile";
 
   export interface DefaultTheme {
     grayScaleColors: {
@@ -32,7 +32,10 @@ declare module "styled-components" {
       [color in TColors]: string;
     };
     widthByDevice: {
-      [width in TWidth]: string;
+      [device in TDevices]: string;
+    };
+    paddingByDevice: {
+      [device in TDevices]: string;
     };
     flexSet: (horizon?: string, vertical?: string, direction?: string) => any;
   }

--- a/src/util/styles/theme/styled.d.ts
+++ b/src/util/styles/theme/styled.d.ts
@@ -1,17 +1,28 @@
-import 'styled-components';
+import "styled-components";
 import Mixin from "../CommonStyledCSS";
 
-declare module 'styled-components' {
+declare module "styled-components" {
   type TGrayScaleColors =
-    | 'titleActive' | 'font' | 'lightFont'
-    | 'placeHolder' | 'line' | 'inputBackground'
-    | 'background' | 'offWhite';
+    | "titleActive"
+    | "font"
+    | "lightFont"
+    | "placeHolder"
+    | "line"
+    | "inputBackground"
+    | "background"
+    | "offWhite";
   type TColors =
-    | 'basicBlue' | 'lightBlue' | 'darkBlue'
-    | 'basicGreen' | 'lightGreen' | 'darkGreen'
-    | 'error' | 'lightRed' | 'darkRed';
-  type TOptions =
-    | "horizon" | "vertical" | "direction"
+    | "basicBlue"
+    | "lightBlue"
+    | "darkBlue"
+    | "basicGreen"
+    | "lightGreen"
+    | "darkGreen"
+    | "error"
+    | "lightRed"
+    | "darkRed";
+  type TOptions = "horizon" | "vertical" | "direction";
+  type TWidth = "desktop" | "mobile";
 
   export interface DefaultTheme {
     grayScaleColors: {
@@ -20,6 +31,9 @@ declare module 'styled-components' {
     colors: {
       [color in TColors]: string;
     };
-    flexSet: (horizon?: string, vertical?: string, direction?: string) => any,
+    widthByDevice: {
+      [width in TWidth]: string;
+    };
+    flexSet: (horizon?: string, vertical?: string, direction?: string) => any;
   }
 }


### PR DESCRIPTION
### 기능요약 (이 PR은 어떤 일을 하나요?)
엔트리 페이지랑 헤더를 반응형으로 제작했습니다.

### 작업내용

- 브라우저 폭이 768px 이하(모바일)일 때 페이지의 좌우 패딩을 `200px` -> `0 2em` 으로 적용했습니다.
- 데스크톱 일땐 페이지 전체 폭을 1920px로 고정했고, 모바일 일땐 뷰포트에 꽉 차도록 `100vw` 로 고정했습니다.
- 히어로 이미지가 모바일일 때, 주요 인물이 잘 보이도록 이미지를 이동시켰습니다.
- 반응형 레이아웃 관련한 테마들을 theme/index.ts 에 선언해두었습니다.
- 모바일 앱 다운로드 버튼을 제거했습니다.
- 아직 폰트나 로고, 버튼 등의 크기는 반응형을 적용하지 못했습니다.

### 이 PR이 필요한 이유 (optional)

- 엔트리 페이지를 작은 화면에서 보면 레이아웃이 엉망으로 되는 문제가 있었습니다.
- 모바일 앱 버튼은 모바일 앱을 출시할 때 넣는게 좋겠다는 의견이 있어서 반영했습니다.

### 변경사항에 대한 렌더링 화면 변화를 캡처해 첨부해주세요. (optional)
![image](https://user-images.githubusercontent.com/71166372/130882375-0677bb51-ce1a-498d-b7a9-36817fdaea1a.png)

