### PR TITLE
개인정보 등록 관련 페이지 url path 변경 & 관심사 등록 페이지 기능 수정

### DIFF
--- a/src/components/Common/Buttons/TargetButton.tsx
+++ b/src/components/Common/Buttons/TargetButton.tsx
@@ -50,8 +50,7 @@ const DeleteButton = styled.button`
   margin: 0;
 
   position: absolute;
-  color: ${({ theme }) => theme.colors.error};
-  font-size: 0.8em;
-  right: 3px;
-  top: 2.5px;
+  font-size: 0.7em;
+  right: -6.6px;
+  top: -3.5px;
 `;

--- a/src/components/Common/Buttons/TargetButton.tsx
+++ b/src/components/Common/Buttons/TargetButton.tsx
@@ -1,25 +1,23 @@
-import { useState, Dispatch, SetStateAction } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
-import RoundButton from "components/Common/Buttons/RoundButton";
-interface ResultProp {
-  location: string;
-  targetLocations: string[];
-  setTargetLocations: Dispatch<SetStateAction<string[]>>;
-}
+import RoundButton from "./RoundButton";
 
-const TargetButton = ({ location, targetLocations, setTargetLocations }: ResultProp) => {
+type TTargetButtonProps = {
+  displayName: string;
+  onDeleteItemClick: (e : React.MouseEvent | MouseEvent) => void,
+  // items: string[];
+  // setItems: Dispatch<SetStateAction<string[]>>;
+};
+
+const TargetButton = ({ displayName, onDeleteItemClick }: TTargetButtonProps) => {
   const [isHoverState, setHoverState] = useState(false);
-  const handleHover = () => {
-    setHoverState((prev) => !prev);
-  };
 
-  const handleDelete = (location: string) => {
-    setTargetLocations(targetLocations.filter((target) => target !== location));
-  };
+  const handleHover = () => setHoverState((prev) => !prev);
+
   return (
     <HoverActive onMouseEnter={handleHover} onMouseLeave={handleHover}>
-      <SelectedItemButton disableRipple={true}>{location}</SelectedItemButton>
-      <DeleteButton isHoverState={isHoverState} onClick={() => handleDelete(location)}>
+      <SelectedItemButton disableRipple={true}>{displayName}</SelectedItemButton>
+      <DeleteButton isHoverState={isHoverState} onClick={onDeleteItemClick}>
         ×
       </DeleteButton>
     </HoverActive>
@@ -38,7 +36,6 @@ const DeleteButton = styled.button<Delete>`
   left: -8px;
 `;
 const SelectedItemButton = styled(RoundButton)`
-  // 중복 (관심사 페이지)
   background-color: ${({ theme }) => theme.grayScaleColors.titleActive};
   color: ${({ theme }) => theme.grayScaleColors.offWhite};
   &:hover {

--- a/src/components/Common/Buttons/TargetButton.tsx
+++ b/src/components/Common/Buttons/TargetButton.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 import styled from "styled-components";
+import { IoClose } from "react-icons/io5";
 import RoundButton from "./RoundButton";
 
 type TTargetButtonProps = {
   displayName: string;
-  onDeleteItemClick: (e : React.MouseEvent | MouseEvent) => void,
+  onDeleteItemClick: (e: React.MouseEvent | MouseEvent) => void;
   // items: string[];
   // setItems: Dispatch<SetStateAction<string[]>>;
 };
@@ -12,34 +13,45 @@ type TTargetButtonProps = {
 const TargetButton = ({ displayName, onDeleteItemClick }: TTargetButtonProps) => {
   const [isHoverState, setHoverState] = useState(false);
 
-  const handleHover = () => setHoverState((prev) => !prev);
+  // const handleHover = () => setHoverState((prev) => !prev);
+  const handleMouseEnter = () => isHoverState || setHoverState((prev) => !prev);
+  const handleMouseLeave = () => isHoverState && setHoverState((prev) => !prev);
 
   return (
-    <HoverActive onMouseEnter={handleHover} onMouseLeave={handleHover}>
+    <TargetButtonLayout onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       <SelectedItemButton disableRipple={true}>{displayName}</SelectedItemButton>
-      <DeleteButton isHoverState={isHoverState} onClick={onDeleteItemClick}>
-        ×
-      </DeleteButton>
-    </HoverActive>
+      {isHoverState && (
+        <DeleteButton onClick={onDeleteItemClick}>
+          <IoClose />
+        </DeleteButton>
+      )}
+    </TargetButtonLayout>
   );
 };
 
-interface Delete {
-  isHoverState: boolean;
-}
+export default TargetButton;
 
-const HoverActive = styled.div``;
-const DeleteButton = styled.button<Delete>`
-  display: ${({ isHoverState }) => (isHoverState ? "block" : "none")};
+const TargetButtonLayout = styled.div`
   position: relative;
-  top: -11px;
-  left: -8px;
 `;
+
 const SelectedItemButton = styled(RoundButton)`
   background-color: ${({ theme }) => theme.grayScaleColors.titleActive};
   color: ${({ theme }) => theme.grayScaleColors.offWhite};
   &:hover {
     background-color: ${({ theme }) => theme.grayScaleColors.titleActive};
+    cursor: default;
   }
 `;
-export default TargetButton;
+
+const DeleteButton = styled.button`
+  ${({ theme }) => theme.flexSet()};
+  padding: 0;
+  margin: 0;
+
+  position: absolute;
+  color: ${({ theme }) => theme.colors.error};
+  font-size: 0.8em;
+  right: 3px;
+  top: 2.5px;
+`;

--- a/src/components/Common/Buttons/index.tsx
+++ b/src/components/Common/Buttons/index.tsx
@@ -1,3 +1,5 @@
+import BlueButton from "./BlueButton";
 import RoundButton from "./RoundButton";
+import TargetButton from "./TargetButton";
 
-export { RoundButton };
+export { BlueButton, RoundButton, TargetButton };

--- a/src/components/Common/ResponsiveContainer/mediaQueries.ts
+++ b/src/components/Common/ResponsiveContainer/mediaQueries.ts
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import { css } from "styled-components";
 
 const maxWidth540 = css`
   @media (min-width: 576px) {
@@ -30,4 +30,4 @@ const maxWidth1320 = css`
   }
 `;
 
-export { maxWidth540, maxWidth720, maxWidth960, maxWidth1140, maxWidth1320};
+export { maxWidth540, maxWidth720, maxWidth960, maxWidth1140, maxWidth1320 };

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -17,7 +17,7 @@ const Header = () => {
     if (location.pathname !== ENTER) return;
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+  }, [location.pathname, ENTER]);
 
   return (
     <HeaderLayout isHeaderTop={isHeaderTop}>

--- a/src/components/Routes/index.tsx
+++ b/src/components/Routes/index.tsx
@@ -1,9 +1,9 @@
-import { EnterPage, LoginPage, MainPage, InterestPage, LocationPage } from "@/pages";
+import { EnterPage, LoginPage, MainPage, RegisterInterestPage, RegisterLocationPage } from "@/pages";
 import { Route, BrowserRouter as Router, Switch } from "react-router-dom";
 import Header from "components/Header";
 import { ROUTE } from "util/constants";
 const Routes = () => {
-  const { ENTER, LOGIN, MAIN, INTEREST, LOCATION } = ROUTE;
+  const { ENTER, LOGIN, MAIN, USER } = ROUTE;
   return (
     <Router>
       <Header />
@@ -12,8 +12,8 @@ const Routes = () => {
         <Route path={LOGIN} component={LoginPage} exact />
         <Route path={MAIN} component={MainPage} exact />
         {/* <Route path ={'/mypage'} component={MyPage} exact /> */}
-        <Route path={INTEREST} component={InterestPage} exact />
-        <Route path={LOCATION} component={LocationPage} exact />
+        <Route path={USER.INTEREST} component={RegisterInterestPage} exact />
+        <Route path={USER.LOCATION} component={RegisterLocationPage} exact />
         {/* <Route path ={'/recruitments/pages/:page'} component={RecruitmentsPage} exact /> */}
         {/* <Route path ={'/recruitments/:id'} component={RecruitmentDetailPage} exact /> */}
         {/* <Route path ={'/recruitments/new'} component={newRecruitmentPage} exact /> */}

--- a/src/components/User/RegisterInterest/RegisterInterest.tsx
+++ b/src/components/User/RegisterInterest/RegisterInterest.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useState } from "react";
 import styled, { css } from "styled-components";
 import { Container } from "@material-ui/core";
-import RoundButton from "components/Common/Buttons/RoundButton";
-import { intersetData } from "util/mockData";
 import { useHistory } from "react-router";
+
+import { RoundButton, TargetButton } from "components/Common/Buttons";
+import { intersetData } from "util/mockData";
+import { ROUTE } from "util/constants"
 
 type TCategoryType = "main" | "sub";
 interface IInterestButton {
@@ -60,7 +62,7 @@ const RegisterInterest = () => {
   };
 
   // 현재 선택한 관심사들에서 클릭한 관심사 제거
-  const handleSelectedItemBtnClick = (e: React.MouseEvent | MouseEvent, selectItemId: string) => {
+  const handleSelectedItemBtnClick = (selectItemId: string) => (e: React.MouseEvent | MouseEvent) => {
     const [mainIdx, subIdx] = selectItemId.split("|").map((v) => +v);
     if (mainIdx <= 0 || subIdx <= 0) return;
     setSelectedBtnInfo((state) => {
@@ -75,7 +77,7 @@ const RegisterInterest = () => {
   // 관심사 5개 선택한 후 주변 장소 설정 페이지로 이동
   const handleNextButtonClick = (e: React.MouseEvent | MouseEvent) => {
     const { items } = selectedBtnInfo;
-    items.length === 5 && history.push('/location');
+    items.length === 5 && history.push(ROUTE.USER.LOCATION);
   };
 
   const mainCategoryBtns = useMemo(
@@ -130,13 +132,11 @@ const RegisterInterest = () => {
             <SeparatedLine />
             <ButtonBox>
               {selectedBtnInfo.items.map(({ mainIdx, subIdx, value }) => (
-                <SelectedItemButton
+                <TargetButton
                   key={`${mainIdx}|${subIdx}`}
-                  disableRipple={true}
-                  onClick={(e) => handleSelectedItemBtnClick(e, `${mainIdx}|${subIdx}`)}
-                >
-                  {value}
-                </SelectedItemButton>
+                  displayName={value || ''}
+                  onDeleteItemClick={handleSelectedItemBtnClick(`${mainIdx}|${subIdx}`)}
+                />
               ))}
             </ButtonBox>
             {selectedBtnInfo.items.length === MAX_SELECT_NUM && (
@@ -202,13 +202,13 @@ const InterestButton = styled(RoundButton)<IInterestButton>`
     `};
 `;
 
-const SelectedItemButton = styled(RoundButton)`
-  background-color: ${({ theme }) => theme.grayScaleColors.titleActive};
-  color: ${({ theme }) => theme.grayScaleColors.offWhite};
-  &:hover {
-    background-color: ${({ theme }) => theme.grayScaleColors.titleActive};
-  }
-`;
+// const SelectedItemButton = styled(RoundButton)`
+//   background-color: ${({ theme }) => theme.grayScaleColors.titleActive};
+//   color: ${({ theme }) => theme.grayScaleColors.offWhite};
+//   &:hover {
+//     background-color: ${({ theme }) => theme.grayScaleColors.titleActive};
+//   }
+// `;
 
 const NextButton = styled(RoundButton)`
   border-radius: 12px;

--- a/src/components/User/RegisterInterest/index.tsx
+++ b/src/components/User/RegisterInterest/index.tsx
@@ -1,0 +1,2 @@
+import RegisterInterest from "./RegisterInterest";
+export default RegisterInterest;

--- a/src/components/User/RegisterLocation/RegisterLocation.tsx
+++ b/src/components/User/RegisterLocation/RegisterLocation.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { useHistory } from "react-router-dom";
-import styled from "styled-components";
 import { Container } from "@material-ui/core";
-import useInput from "@/hooks/useInput";
+import styled from "styled-components";
 import { FiSearch } from "react-icons/fi";
-import { Link } from "react-router-dom";
-import RoundButton from "components/Common/Buttons/RoundButton";
-import TargetButton from "./TargetButton";
+
+import useInput from "@/hooks/useInput";
+import { RoundButton, TargetButton } from "components/Common/Buttons";
 import { ROUTE } from "util/constants";
+
 type Address = {
   [key: string]: string;
 };
@@ -19,6 +19,7 @@ interface LocationResult {
   x: string;
   y: string;
 }
+
 const RegisterLocation = () => {
   const history = useHistory();
   const [locationInput, onChangeLocation, setLocationInput] = useInput("");
@@ -45,6 +46,10 @@ const RegisterLocation = () => {
     } //태그2개이상선택시 return
 
     setTargetLocations((prev) => prev.concat([dongName]));
+  };
+
+  const handleDeleteTarget = (location: string) => () => {
+    setTargetLocations(targetLocations.filter((target) => target !== location));
   };
 
   const handleNextPage = () => {
@@ -96,9 +101,8 @@ const RegisterLocation = () => {
             {targetLocations.map((location, idx) => (
               <TargetButton
                 key={idx}
-                location={location}
-                targetLocations={targetLocations}
-                setTargetLocations={setTargetLocations}
+                displayName={location}
+                onDeleteItemClick={handleDeleteTarget(location)}
               />
             ))}
           </ButtonBox>

--- a/src/components/User/RegisterLocation/index.tsx
+++ b/src/components/User/RegisterLocation/index.tsx
@@ -1,0 +1,2 @@
+import RegisterLocation from "./RegisterLocation";
+export default RegisterLocation;

--- a/src/pages/InterestPage.tsx
+++ b/src/pages/InterestPage.tsx
@@ -1,8 +1,0 @@
-// 개인정보등록 : 관심사
-
-import RegisterInterest from "components/RegisterInterest";
-
-const InterestPage = () => {
-  return <RegisterInterest />;
-};
-export default InterestPage;

--- a/src/pages/LocationPage.tsx
+++ b/src/pages/LocationPage.tsx
@@ -1,8 +1,0 @@
-// 개인정보등록 : 장소
-
-import RegisterLocation from "components/RegisterLocation";
-
-const LocationPage = () => {
-  return <RegisterLocation />;
-};
-export default LocationPage;

--- a/src/pages/User/RegisterInterestPage.tsx
+++ b/src/pages/User/RegisterInterestPage.tsx
@@ -1,0 +1,7 @@
+// 개인정보등록 : 관심사
+import RegisterInterest from "components/User/RegisterInterest";
+
+const RegisterInterestPage = () => {
+  return <RegisterInterest />;
+};
+export default RegisterInterestPage;

--- a/src/pages/User/RegisterLocationPage.tsx
+++ b/src/pages/User/RegisterLocationPage.tsx
@@ -1,0 +1,7 @@
+// 개인정보등록 : 장소
+import RegisterLocation from "components/User/RegisterLocation";
+
+const RegisterLocationPage = () => {
+  return <RegisterLocation />;
+};
+export default RegisterLocationPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,27 +1,28 @@
 // pages : index
 import EnterPage from './EnterPage';
-import HostRegistrationPage from './HostRegistrationPage';
 import LoginPage from './LoginPage';
+import RegisterInterestPage from './User/RegisterInterestPage';
+import RegisterLocationPage from './User/RegisterLocationPage';
+import HostRegistrationPage from './HostRegistrationPage';
 import MainPage from './MainPage';
 import MyInfoPage from './MyInfoPage';
 import StudyGroupingDetailPage from './StudyGroupingDetailPage';
 import RecruitmentsPage from './RecruitmentsPage';
 import RoomBookingPage from './RoomBookingPage';
 import RoomDetailPage from './RoomDetailPage';
-import InterestPage from './InterestPage';
-import LocationPage from './LocationPage';
+
 
 export {
   EnterPage,
-  HostRegistrationPage,
   LoginPage,
+  RegisterInterestPage,
+  RegisterLocationPage,
+  HostRegistrationPage,
   MainPage,
   MyInfoPage,
   StudyGroupingDetailPage,
   RecruitmentsPage,
   RoomBookingPage,
   RoomDetailPage,
-  InterestPage,
-  LocationPage,
 };
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -2,6 +2,8 @@ export const ROUTE = {
   ENTER: "/",
   LOGIN: "/login",
   MAIN: "/main",
-  INTEREST: "/interest",
-  LOCATION: "/location",
+  USER: {
+    INTEREST: "/user/interest",
+    LOCATION: "/user/location",
+  },
 };

--- a/src/util/styles/GlobalStyle.tsx
+++ b/src/util/styles/GlobalStyle.tsx
@@ -14,12 +14,10 @@ import reset from "styled-reset";
 
 const GlobalStyle = createGlobalStyle`
   ${reset};
-  
 	* {
     box-sizing: border-box;
-    
   }
-  
+
   body {
     font-family:'Nunito_Regular';
     font-size: 18px;
@@ -43,50 +41,50 @@ const GlobalStyle = createGlobalStyle`
   }
 
   @font-face {
-    font-family: 'Nunito_Black';	
-    src: local('Nunito_Black'),    
+    font-family: 'Nunito_Black';
+    src: local('Nunito_Black'),
     url(${Nunito_Black})format('woff');
   }
 
   @font-face {
-    font-family: 'Nunito_ExtraBold';	
-    src: local('Nunito_ExtraBold'),    
+    font-family: 'Nunito_ExtraBold';
+    src: local('Nunito_ExtraBold'),
     url(${Nunito_ExtraBold})format('woff');
   }
 
   @font-face {
-    font-family: 'Nunito_Bold';	
-    src: local('Nunito_Bold'),    
+    font-family: 'Nunito_Bold';
+    src: local('Nunito_Bold'),
     url(${Nunito_Bold})format('woff');
   }
 
   @font-face {
-    font-family: 'Nunito_SemiBold';	
-    src: local('Nunito_SemiBold'),    
+    font-family: 'Nunito_SemiBold';
+    src: local('Nunito_SemiBold'),
     url(${Nunito_SemiBold})format('woff');
   }
 
   @font-face {
-    font-family: 'Nunito_Regular';	
-    src: local('Nunito_Regular'),    
+    font-family: 'Nunito_Regular';
+    src: local('Nunito_Regular'),
     url(${Nunito_Regular})format('woff');
   }
 
   @font-face {
-    font-family: 'Nunito_Light';	
-    src: local('Nunito_Light'),    
+    font-family: 'Nunito_Light';
+    src: local('Nunito_Light'),
     url(${Nunito_Light})format('woff');
   }
 
   @font-face {
-    font-family: 'Nunito_ExtraLight';	
-    src: local('Nunito_ExtraLight'),    
+    font-family: 'Nunito_ExtraLight';
+    src: local('Nunito_ExtraLight'),
     url(${Nunito_ExtraLight})format('woff');
   }
 
   @font-face {
-    font-family: 'Nunito_ExtraBoldItalic';	
-    src: local('Nunito_ExtraBoldItalic'),    
+    font-family: 'Nunito_ExtraBoldItalic';
+    src: local('Nunito_ExtraBoldItalic'),
     url(${Nunito_ExtraBoldItalic})format('woff');
   }
 `;

--- a/src/util/styles/theme/styled.d.ts
+++ b/src/util/styles/theme/styled.d.ts
@@ -1,5 +1,4 @@
 import "styled-components";
-import Mixin from "../CommonStyledCSS";
 
 declare module "styled-components" {
   type TGrayScaleColors =
@@ -37,6 +36,6 @@ declare module "styled-components" {
     paddingByDevice: {
       [device in TDevices]: string;
     };
-    flexSet: (horizon?: string, vertical?: string, direction?: string) => any;
+    flexSet: (horizon?: string, vertical?: string, direction?: string) => FlattenSimpleInterpolation;
   }
 }


### PR DESCRIPTION
### 기능요약 (이 PR은 어떤 일을 하나요?)

- 개인정보 등록 : 관심사 페이지 - 선택 기능
- 개인정보 등록 관련 페이지의 공통된 부분 일부 컴포넌트화 

### 작업내용

- #26 
  - 개인정보 등록 : 관심사 페이지의 선택 기능 완성
- #28 
  - 개인정보 등록 : 관심사 & 장소등록에서 쓰이는 공통된 컴포넌트인 TargetButton 리팩토링
- 참고: [노션 개발일지 - 개인정보 등록 : 관심사 & 장소등록 리팩토링](https://boiled-feather-1c7.notion.site/d1ceb9e9214f459db83f3493ba17620c)

### 이 PR이 필요한 이유

- 컴포넌트의 분류를 더 명확하게 하기 위해 url path와 디렉토리 구조를 분리 및 변경
- 개인정보 등록 : 관심사 & 장소등록. 2 페이지 모두 겹치는 컴포넌트가 있음
